### PR TITLE
blacklist renderer "Internet Explorer" (weird breakage)

### DIFF
--- a/src/renderer/base.js
+++ b/src/renderer/base.js
@@ -7,7 +7,16 @@ XML3D.webgl = {
 
         return function () {
             try {
-                return !!(window.WebGLRenderingContext && (canvas.getContext('experimental-webgl')));
+                var hasContextClass = !!(window.WebGLRenderingContext);
+                if (hasContextClass) {
+                    var context = canvas.getContext('experimental-webgl');
+                    if (!!context) {
+                        var renderer = context.getParameter(context.RENDERER);
+                        // IE 11 does not work yet :-(
+                        return renderer !== "Internet Explorer";
+                    }
+                }
+                return false;
             } catch (e) {
                 return false;
             }


### PR DESCRIPTION
While IE11 does have WebGL, a lot of features are (apparently) missing, which causes breaks somewhere deep in the Bounding Box code. For the moment, IE11 should be blacklisted such that a website visitor gets a proper "not supported" box, instead of (potentially invisible) exceptions in the console.